### PR TITLE
fix(jsx): import React because transpiled JSX requires it

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -235,6 +235,7 @@
     "space-unary-ops": 2,
 
     /* ES6+ */
+
     // disallow using `var`. Must use `let` or `const`
     "no-var": 2,
     "no-class-assign": 2,
@@ -248,6 +249,11 @@
     "arrow-spacing": 2,
     "prefer-arrow-callback": 2,
     "arrow-parens": [0, "as-needed"],
+
+    /* React */
+
+    // Prevent React to be incorrectly marked as unused
+    "react/jsx-uses-react": 2,
   },
   "env": {
     "browser": true,
@@ -258,5 +264,8 @@
   },
   "ecmaFeatures": {
     "jsx": true
-  }
+  },
+  "plugins": [
+    "react"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
     "eslint": "^2.10.2",
+    "eslint-plugin-react": "5.1.1",
     "mocha": "^2.4.5",
     "promise": "^7.1.1",
     "react": "^15.0.2",

--- a/src/dispatchOnMount.js
+++ b/src/dispatchOnMount.js
@@ -1,4 +1,4 @@
-import { Component, PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { Subscription } from 'rxjs/Subscription';
 
 const $$reduxObservableSubscription = '@@reduxObservableSubscription';


### PR DESCRIPTION
This isn't breaking in tests because we're not actually rendering the components. We should probably switch to doing that so we test everything.
