### PR TITLE
feat(factories): dispatchOnMount() now expects factories

### DIFF
--- a/src/dispatchOnMount.js
+++ b/src/dispatchOnMount.js
@@ -3,7 +3,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 const $$reduxObservableSubscription = '@@reduxObservableSubscription';
 
-export function dispatchOnMount(...toDispatch) {
+export function dispatchOnMount(...factories) {
   return (ComposedComponent) =>
     class DispatchOnMountComponent extends Component {
       static contextTypes = {
@@ -12,7 +12,7 @@ export function dispatchOnMount(...toDispatch) {
 
       componentDidMount() {
         this[$$reduxObservableSubscription] = new Subscription();
-        toDispatch.map(a => this.context.store.dispatch(a))
+        factories.map(factory => this.context.store.dispatch(factory(this.props)))
           .forEach(sub => sub && this[$$reduxObservableSubscription].add(sub));
       }
 
@@ -21,7 +21,7 @@ export function dispatchOnMount(...toDispatch) {
       }
 
       render() {
-        return (<ComposedComponent {...this.props}/>);
+        return (<ComposedComponent {...this.props} />);
       }
     };
 }


### PR DESCRIPTION
fixes #4

It's important to note that if you need props from the redux store, the order in which you compose is important. You **must** wrap the `@connect` component around the `@dispatchToMount` component.

``` jsx
export default connect(mapStateToProps)(
  dispatchOnMount(props => fetchUserById(props.user.id))(
    UserComponent
  )
);
```

Currently, both babel and typescript invoke decorators top to bottom, but as of this writing the latest decorators spec invokes them in reverse order. This will undoubtedly bite people when transpilers start supporting the new spec. Not sure there's anything that can be done about it.
