### PR TITLE
fix(package): remove redux-observable as a hard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://github.com/redux-observable/react-redux-observable#README.md",
   "peerDependencies": {
     "redux": "3.*",
-    "rxjs": "^5.0.0-beta.6"
+    "rxjs": "^5.*",
+    "react": "^14.*"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",
@@ -72,13 +73,11 @@
     "eslint-plugin-react": "5.1.1",
     "mocha": "^2.4.5",
     "promise": "^7.1.1",
-    "react": "^15.0.2",
+    "react": "^15.1.0",
     "redux": "^3.5.2",
+    "redux-observable": "^0.5.0",
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.7",
     "typescript": "^1.8.10"
-  },
-  "dependencies": {
-    "redux-observable": "^0.4.0"
   }
 }


### PR DESCRIPTION
redux-observable is no longer a hard dependency.
redux, react and rxjs are now peer dependencies

fixes #7
